### PR TITLE
Fix BC date off-by-one bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,14 +35,15 @@ module.exports = function parseDate (isoDate) {
   var date
   var offset = timeZoneOffset(isoDate)
   if (offset != null) {
-    var utc = Date.UTC(year, month, day, hour, minute, second, ms)
-    date = new Date(utc - offset)
+    date = new Date(Date.UTC(year, month, day, hour, minute, second, ms))
 
     // Account for years from 0 to 99 being interpreted as 1900-1999
     // by Date.UTC / the multi-argument form of the Date constructor
     if (is0To99(year)) {
       date.setUTCFullYear(year)
     }
+
+    date.setTime(date.getTime() - offset)
   } else {
     date = new Date(year, month, day, hour, minute, second, ms)
 

--- a/index.js
+++ b/index.js
@@ -32,23 +32,21 @@ module.exports = function parseDate (isoDate) {
   var ms = matches[7]
   ms = ms ? 1000 * parseFloat(ms) : 0
 
-  // Years from 0 to 99 are interpreted as 1900-1999
-  // by the multi-argument form of the date constructor
-  var yearIs0To99 = year >= 0 && year < 100
-
   var date
   var offset = timeZoneOffset(isoDate)
   if (offset != null) {
     var utc = Date.UTC(year, month, day, hour, minute, second, ms)
     date = new Date(utc - offset)
 
-    if (yearIs0To99) {
+    // Account for years from 0 to 99 being interpreted as 1900-1999
+    // by Date.UTC / the multi-argument form of the Date constructor
+    if (is0To99(year)) {
       date.setUTCFullYear(year)
     }
   } else {
     date = new Date(year, month, day, hour, minute, second, ms)
 
-    if (yearIs0To99) {
+    if (is0To99(year)) {
       date.setFullYear(year)
     }
   }
@@ -72,7 +70,11 @@ function getDate (isoDate) {
   var day = matches[3]
   // YYYY-MM-DD will be parsed as local time
   var date = new Date(year, month, day)
-  date.setFullYear(year)
+
+  if (is0To99(year)) {
+    date.setFullYear(year)
+  }
+
   return date
 }
 
@@ -100,4 +102,8 @@ function bcYearToNegativeYear (year) {
   // Account for numerical difference between representations of BC years
   // See: https://github.com/bendrucker/postgres-date/issues/5
   return -(year - 1)
+}
+
+function is0To99 (num) {
+  return num >= 0 && num < 100
 }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function parseDate (isoDate) {
 
   if (!matches) {
     // Force YYYY-MM-DD dates to be parsed as local time
-    return DATE.test(isoDate) ? getDate(isoDate) : null
+    return getDate(isoDate) || null
   }
 
   var isBC = !!matches[8]
@@ -58,6 +58,9 @@ module.exports = function parseDate (isoDate) {
 
 function getDate (isoDate) {
   var matches = DATE.exec(isoDate)
+  if (!matches) {
+    return
+  }
 
   var year = parseInt(matches[1], 10)
   var isBC = !!matches[4]

--- a/index.js
+++ b/index.js
@@ -15,9 +15,7 @@ module.exports = function parseDate (isoDate) {
 
   if (!matches) {
     // Force YYYY-MM-DD dates to be parsed as local time
-    return DATE.test(isoDate) ?
-      getDate(isoDate) :
-      null
+    return DATE.test(isoDate) ? getDate(isoDate) : null
   }
 
   var isBC = BC.test(isoDate)

--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 'use strict'
 
-var DATE_TIME = /(\d{1,})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?/
+var DATE_TIME = /(\d{1,})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?.*?( BC)?$/
 var DATE = /^(\d{1,})-(\d{2})-(\d{2})( BC)?$/
 var TIME_ZONE = /([Z+-])(\d{2})?:?(\d{2})?:?(\d{2})?/
-var BC = /BC$/
 var INFINITY = /^-?infinity$/
 
 module.exports = function parseDate (isoDate) {
@@ -18,7 +17,7 @@ module.exports = function parseDate (isoDate) {
     return DATE.test(isoDate) ? getDate(isoDate) : null
   }
 
-  var isBC = BC.test(isoDate)
+  var isBC = !!matches[8]
   var year = parseInt(matches[1], 10)
   if (isBC) {
     year = bcYearToNegativeYear(year)

--- a/index.js
+++ b/index.js
@@ -23,7 +23,6 @@ module.exports = function parseDate (isoDate) {
   if (isBC) {
     year = bcYearToNegativeYear(year)
   }
-  var yearIsBetween0And99 = year >= 0 && year < 100
 
   var month = parseInt(matches[2], 10) - 1
   var day = matches[3]
@@ -34,17 +33,25 @@ module.exports = function parseDate (isoDate) {
   var ms = matches[7]
   ms = ms ? 1000 * parseFloat(ms) : 0
 
+  // Years from 0 to 99 are interpreted as 1900-1999
+  // by the multi-argument form of the date constructor
+  var yearIs0To99 = year >= 0 && year < 100
+
   var date
   var offset = timeZoneOffset(isoDate)
   if (offset != null) {
     var utc = Date.UTC(year, month, day, hour, minute, second, ms)
     date = new Date(utc - offset)
+
+    if (yearIs0To99) {
+      date.setUTCFullYear(year)
+    }
   } else {
     date = new Date(year, month, day, hour, minute, second, ms)
-  }
 
-  if (yearIsBetween0And99) {
-    date.setUTCFullYear(year)
+    if (yearIs0To99) {
+      date.setFullYear(year)
+    }
   }
 
   return date

--- a/test.js
+++ b/test.js
@@ -96,6 +96,12 @@ test('date parser', function (t) {
     'negative HH:mm:ss offset'
   )
 
+  t.equal(
+    iso('0076-01-01 01:30:15+12'),
+    '0075-12-31T13:30:15.000Z',
+    '0 to 99 year boundary'
+  )
+
   t.equal(parse('infinity'), Infinity)
   t.equal(parse('-infinity'), -Infinity)
 

--- a/test.js
+++ b/test.js
@@ -11,11 +11,19 @@ test('date parser', function (t) {
     new Date('2010-12-11 09:09:04').toString()
   )
 
-  var ancient = new Date('2010-12-11 09:09:04')
-  ancient.setFullYear(-2010)
   t.equal(
-    parse('2010-12-11 09:09:04 BC').toString(),
-    ancient.toString()
+    parse('2011-12-11 09:09:04 BC').toString(),
+    new Date('-002010-12-11T09:09:04').toString()
+  )
+
+  t.equal(
+    parse('0001-12-11 09:09:04 BC').toString(),
+    new Date('0000-12-11T09:09:04').toString()
+  )
+
+  t.equal(
+    parse('0001-12-11 BC').getFullYear(),
+    0
   )
 
   t.equal(


### PR DESCRIPTION
Fixes #5 

Also fixes BC `date` type output, which currently isn't parsing at all. e.g. `1234-01-01 BC`

Related: brianc/node-postgres#1864