### PR TITLE
Make millisecond rounding an opt-in behavior

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,19 @@ parse('2011-01-23 22:15:51Z')
 // => 2011-01-23T22:15:51.000Z
 ```
 
+### Rounding
+The default parser truncates dates at the millisecond level.  Any microsecond information is discarded similar to 
+how most standard javascript date parsers work.
+
+There are some use cases where rounding to the nearest millisecond is preferable.  In those cases, you can
+use the following parser:
+
+```js
+var parse = require('postgres-date');
+parse.parseDateRounded('2011-01-23 22:15:51.323974Z');
+// -> 2011-01-23T22:15:51.324Z
+```
+
 ## API
 
 #### `parse(isoDate)` -> `date`
@@ -35,6 +48,17 @@ parse('2011-01-23 22:15:51Z')
 Type: `string`
 
 A date string from Postgres.
+
+#### `parse.parseDateRounded(isoDate)` -> `date`
+
+Returns a `Date`, rounded to the nearest millisecond.
+
+##### isoDate
+
+*Required*  
+Type: `string`
+
+A date string from Postgres
 
 ## Releases
 

--- a/test.js
+++ b/test.js
@@ -56,8 +56,14 @@ test('date parser', function (t) {
 
   t.equal(
     iso('2011-01-23 22:15:51.280843-06'),
-    '2011-01-24T04:15:51.281Z',
+    '2011-01-24T04:15:51.280Z',
     'huge ms value'
+  )
+
+  t.equal(
+    parse.parseDateRounded('2011-01-23 22:15:51.280843-06').toISOString(),
+    '2011-01-24T04:15:51.281Z',
+    'huge ms value with rounding enabled'
   )
 
   t.equal(


### PR DESCRIPTION
https://github.com/bendrucker/postgres-date/issues/14

I'd rather just remove the rounding functionality altogether, but by making it optional, we can support both use-cases.