### PR TITLE
Improve parsing performance for default format

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,10 @@ function getDate (isoDate) {
 // -05
 // +06:30
 function timeZoneOffset (isoDate) {
+  if (isoDate.endsWith('+00')) {
+    return 0
+  }
+
   var zone = TIME_ZONE.exec(isoDate.split(' ')[1])
   if (!zone) return
   var type = zone[1]

--- a/index.js
+++ b/index.js
@@ -43,7 +43,9 @@ module.exports = function parseDate (isoDate) {
       date.setUTCFullYear(year)
     }
 
-    date.setTime(date.getTime() - offset)
+    if (offset !== 0) {
+      date.setTime(date.getTime() - offset)
+    }
   } else {
     date = new Date(year, month, day, hour, minute, second, ms)
 


### PR DESCRIPTION
When returning large result sets with date columns a significant portion of time is spend in parsing those dates.

By default Postgres returns ISO 8601 UTC time strings so I think it could make sense to fast-case this format in this library.

Doing that improves throughput quite significantly for me.

Tested with the output of `select current_timestamp;` `2020-08-28 19:16:25.651396+00` from an AWS RDS PG 11 instance.

```
  Parse original:
    808 674 ops/s, ±0.69%     | slowest, 35.23% slower

  Parse with fast-case +00:
    1 185 935 ops/s, ±0.40%   | 5.01% slower

  Parse with fast-case + apply offset:
    1 248 458 ops/s, ±0.37%   | fastest
```