### PR TITLE
feat: add Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare function parseDate(isoDate: string): Date | number | null
+declare function parseDate(isoDate: null | undefined): null
+export default parseDate

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,11 @@
+import { expectType, expectError } from 'tsd'
+
+import parse from '.'
+
+expectType<Date | number | null>(parse('2010-12-11 09:09:04'))
+expectType<Date | number | null>(parse('infinity'))
+expectType<Date | number | null>(parse('garbage'))
+expectType<null>(parse(null))
+expectType<null>(parse(undefined))
+expectError(parse(1625042787))
+expectError(parse(new Date()))

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=12"
   },
   "scripts": {
-    "test": "standard && tape test.js"
+    "test": "standard && tape test.js && tsd"
   },
   "keywords": [
     "postgres",
@@ -24,10 +24,12 @@
   "dependencies": {},
   "devDependencies": {
     "standard": "^16.0.0",
-    "tape": "^5.0.0"
+    "tape": "^5.0.0",
+    "tsd": "^0.17.0"
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "readme.md"
   ]
 }


### PR DESCRIPTION
Currently, importing `postgres-date` in a Typescript project leads to error:

```
Could not find a declaration file for module 'postgres-date'. '/Users/semenov/work/xxx/node_modules/postgres-date/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/postgres-date` if it exists or add a new declaration (.d.ts) file containing `declare module 'postgres-date';`ts(7016)
```

This PR adds typings for the exported function.

Note that `Inifinity` / `-Infinity` can not be used as number literal types yet (see https://github.com/microsoft/TypeScript/issues/32277) that's why I mark the return type as `Date | number`.