### PR TITLE
Pin TSD to support Node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "standard": "^17.0.0",
     "tape": "^5.0.0",
-    "tsd": "^0.28.1"
+    "tsd": "< 0.22.0"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
Fixes #42.

It looks like your CI pipeline is passing even though it looks to me like it should fail, so there must be something going on that I don't fully understand. If this is misguided then please close.

In any case, the tests were not running on my machine with TSD 28 on Node 12. This change is tested locally on Node 12 and Node 24.