### PR TITLE
Raise minimum Node version to 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ jobs:
     strategy:
       matrix:
         node-version:
-        - '12'
-        - '14'
+        - '20'
+        - 'lts/*'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "bendrucker.me"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=20"
   },
   "scripts": {
     "test": "standard && tape test.js && tsd"


### PR DESCRIPTION
Raise the minimum Node.js version from 12 to 20 (current maintenance LTS) and update CI to test against 20 and `lts/*`. Also updates `actions/checkout` and `actions/setup-node` to v4.

Closes #42
Closes #43
